### PR TITLE
Permit to retrieve and set the Node IDs

### DIFF
--- a/starlasu-client/src/functionalTest/kotlin/JavaFunctionalTest.kt
+++ b/starlasu-client/src/functionalTest/kotlin/JavaFunctionalTest.kt
@@ -35,26 +35,31 @@ class JavaFunctionalTest : AbstractFunctionalTest() {
 
         // We create an empty partition
         val partition = SimplePartition()
-        kolasuClient.createPartition(partition, "myPartition")
+        kolasuClient.idProvider[partition] = "myPartition"
+        kolasuClient.createPartition(partition)
 
         val partitionIDs = kolasuClient.getPartitionIDs()
-        assertEquals(listOf("myPartition_root"), partitionIDs)
+        val expectedPartitionId = kolasuClient.idFor(partition)
+        assertEquals("myPartition", expectedPartitionId)
+        assertEquals(listOf(expectedPartitionId), partitionIDs)
 
         // Now we want to attach a tree to the existing partition
         val javaAst1 = JavaKolasuParser().parse("""class A {}""").root!!
 
-        kolasuClient.appendTree(javaAst1, "myPartition_root", SimplePartition::stuff)
+        kolasuClient.appendTree(javaAst1, expectedPartitionId, SimplePartition::stuff)
 
         // I can retrieve the entire partition
         partition.stuff.add(javaAst1)
         partition.assignParents()
-        val retrievedPartition = kolasuClient.retrieve("myPartition_root")
+        val retrievedPartition = kolasuClient.retrieve(expectedPartitionId)
         assertEquals(partition, retrievedPartition)
 
         // I can retrieve just a portion of that partition. In that case the parent of the root of the
         // subtree will appear null
         javaAst1.parent = null
-        val retrievedAST1 = kolasuClient.retrieve("myPartition_root_stuff_0")
+        val expectedJavaAst1Id = kolasuClient.idFor(javaAst1)
+        assertEquals("myPartition", expectedPartitionId)
+        val retrievedAST1 = kolasuClient.retrieve(expectedJavaAst1Id)
         assertEquals(
             javaAst1,
             retrievedAST1,
@@ -72,33 +77,34 @@ class JavaFunctionalTest : AbstractFunctionalTest() {
 
         // We create an empty partition
         val partition = SimplePartition()
-        kolasuClient.createPartition(partition, "myPartition")
+        kolasuClient.idProvider[partition] = "myPartition"
+        kolasuClient.createPartition(partition)
 
         val partitionIDs = kolasuClient.getPartitionIDs()
-        assertEquals(listOf("myPartition_root"), partitionIDs)
+        assertEquals(listOf("myPartition"), partitionIDs)
 
         // Now we want to attach several trees to the existing partition
         val javaAst1 = JavaKolasuParser().parse("""class A {}""").root!!
-        kolasuClient.appendTree(javaAst1, "myPartition_root", SimplePartition::stuff)
+        kolasuClient.appendTree(javaAst1, "myPartition", SimplePartition::stuff)
 
         val javaAst2 = JavaKolasuParser().parse("""class B {}""").root!!
-        kolasuClient.appendTree(javaAst2, "myPartition_root", SimplePartition::stuff)
+        kolasuClient.appendTree(javaAst2, "myPartition", SimplePartition::stuff)
 
         val javaAst3 = JavaKolasuParser().parse("""class C {}""").root!!
-        kolasuClient.appendTree(javaAst3, "myPartition_root", SimplePartition::stuff)
+        kolasuClient.appendTree(javaAst3, "myPartition", SimplePartition::stuff)
 
         // I can retrieve the entire partition
         partition.stuff.add(javaAst1)
         partition.stuff.add(javaAst2)
         partition.stuff.add(javaAst3)
         partition.assignParents()
-        val retrievedPartition = kolasuClient.retrieve("myPartition_root")
+        val retrievedPartition = kolasuClient.retrieve("myPartition")
         assertEquals(partition, retrievedPartition)
 
         // I can retrieve just a portion of that partition. In that case the parent of the root of the
         // subtree will appear null
         javaAst1.parent = null
-        val retrievedAST1 = kolasuClient.retrieve("myPartition_root_stuff_0")
+        val retrievedAST1 = kolasuClient.retrieve("myPartition_stuff_0")
         assertEquals(
             javaAst1,
             retrievedAST1,
@@ -106,7 +112,7 @@ class JavaFunctionalTest : AbstractFunctionalTest() {
         assertEquals(null, retrievedAST1.parent)
 
         javaAst2.parent = null
-        val retrievedAST2 = kolasuClient.retrieve("myPartition_root_stuff_1")
+        val retrievedAST2 = kolasuClient.retrieve("myPartition_stuff_1")
         assertEquals(
             javaAst2,
             retrievedAST2,
@@ -114,7 +120,7 @@ class JavaFunctionalTest : AbstractFunctionalTest() {
         assertEquals(null, retrievedAST2.parent)
 
         javaAst3.parent = null
-        val retrievedAST3 = kolasuClient.retrieve("myPartition_root_stuff_2")
+        val retrievedAST3 = kolasuClient.retrieve("myPartition_stuff_2")
         assertEquals(
             javaAst3,
             retrievedAST3,

--- a/starlasu-client/src/functionalTest/kotlin/TodoFunctionalTest.kt
+++ b/starlasu-client/src/functionalTest/kotlin/TodoFunctionalTest.kt
@@ -1,3 +1,9 @@
+import com.strumenta.kolasu.lionweb.KNode
+import com.strumenta.kolasu.model.Point
+import com.strumenta.kolasu.model.Position
+import com.strumenta.kolasu.model.SimpleOrigin
+import com.strumenta.kolasu.model.Source
+import com.strumenta.kolasu.model.SyntheticSource
 import com.strumenta.kolasu.model.assignParents
 import com.strumenta.lwrepoclient.kolasu.KolasuClient
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -21,10 +27,15 @@ class TodoFunctionalTest : AbstractFunctionalTest() {
 
         // We create an empty partition
         val todoAccount = TodoAccount(mutableListOf())
-        kolasuClient.createPartition(todoAccount, "my-base")
+        // By default the partition IDs are derived from the source
+        todoAccount.setSource(SyntheticSource("my-wonderful-partition"))
+        kolasuClient.createPartition(todoAccount)
+
+        val expectedPartitionId = kolasuClient.idFor(todoAccount)
+        assertEquals("synthetic_my-wonderful-partition", expectedPartitionId)
 
         val partitionIDs = kolasuClient.getPartitionIDs()
-        assertEquals(listOf("my-base_root"), partitionIDs)
+        assertEquals(listOf(expectedPartitionId), partitionIDs)
 
         // Now we want to attach a tree to the existing partition
         val todoProject =
@@ -38,17 +49,19 @@ class TodoFunctionalTest : AbstractFunctionalTest() {
             )
         todoProject.assignParents()
 
-        kolasuClient.appendTree(todoProject, containerId = "my-base_root", containment = TodoAccount::projects)
+        kolasuClient.appendTree(todoProject, containerId = expectedPartitionId, containment = TodoAccount::projects)
 
         // I can retrieve the entire partition
         todoAccount.projects.add(todoProject)
         todoAccount.assignParents()
-        val retrievedTodoAccount = kolasuClient.retrieve("my-base_root")
+        val retrievedTodoAccount = kolasuClient.retrieve(expectedPartitionId)
         assertEquals(todoAccount, retrievedTodoAccount)
 
         // I can retrieve just a portion of that partition. In that case the parent of the root of the
         // subtree will appear null
-        val retrievedTodoProject = kolasuClient.retrieve("my-base_root_projects_0")
+        val expectedProjectId = kolasuClient.idFor(todoProject)
+        assertEquals("synthetic_my-wonderful-partition_projects_0", expectedProjectId)
+        val retrievedTodoProject = kolasuClient.retrieve(expectedProjectId)
         assertEquals(
             TodoProject(
                 "My errands list",
@@ -62,4 +75,8 @@ class TodoFunctionalTest : AbstractFunctionalTest() {
         )
         assertEquals(null, retrievedTodoProject.parent)
     }
+}
+
+private fun KNode.setSource(source: Source) {
+    this.origin = SimpleOrigin(Position(Point(1, 0), Point(1, 0), source), null)
 }


### PR DESCRIPTION
Fix #9 

Now the KolasuClient remembers Node IDs associated to nodes on setting or retrieval. In this way it is possible to ask the KolasuClient for the Node ID associated to a certain Kolasu Node.